### PR TITLE
Second order mesh generation with defeaturing/simplification applied

### DIFF
--- a/src/mesh/mesherclass.cpp
+++ b/src/mesh/mesherclass.cpp
@@ -866,6 +866,8 @@ void MesherClass::generateMesh()
                     int NbFaces = myMeshDB->MapOfBodyTopologyMap.value(bodyIndex).faceMap.Extent();
                     for(int faceNr = 1; faceNr<=NbFaces; faceNr++)
                     {
+                        if(myMeshDB->ArrayOfMeshDSOnFaces.getValue(bodyIndex,faceNr).IsNull()) continue;
+
                         occHandle(Ng_MeshVS_DataSourceFace) aFaceFirstOrderFaceMesh =
                                 occHandle(Ng_MeshVS_DataSourceFace)::DownCast(myMeshDB->ArrayOfMeshDSOnFaces.getValue(bodyIndex,faceNr));
                         occHandle(Ng_MeshVS_DataSourceFace) aSecondOrderFaceMesh =


### PR DESCRIPTION
Defeaturing could result in NULL face mesh data sources.
The line

if(myMeshDB->ArrayOfMeshDSOnFaces.getValue(bodyIndex,faceNr).IsNull())
continue;

solves the issue